### PR TITLE
add population to building stats

### DIFF
--- a/workers/completeness-aoi/map.js
+++ b/workers/completeness-aoi/map.js
@@ -3,12 +3,15 @@
 module.exports = function(data, tile, writeData, done) {
     var units = 0;
     var sumIndex = 0;
+    var population = 0;
     data.completeness.completeness.features.forEach(function (feature) {
         if (feature.properties.index) {
             units = units + 1;
             sumIndex = sumIndex + feature.properties.index;
+            var actual = JSON.parse(feature.properties.actual);
+            population = population + actual['pop_sum'];
         }
     })
     
-    done(null, {'units': units, 'sumIndex': sumIndex});
+    done(null, {'units': units, 'sumIndex': sumIndex, 'population': population});
 };


### PR DESCRIPTION
@kamicut this adds `population` attribute to the aoi stats:

```
{
    "buildingYes": 58096,
    "buildingResidential": 183,
    "buildingResidentialIncomplete": 183,
    "totalBuildings": 62262,
    "averageCompleteness": 0.15610705215206788,
    "duplicateCount": 32,
    "untaggedWays": 47,
    "population": 20984.983910959098
}
```
fixes https://github.com/hotosm/osma-health-workers/issues/13